### PR TITLE
Add local model support for prompt variants

### DIFF
--- a/agent_list/Local.py
+++ b/agent_list/Local.py
@@ -1,0 +1,85 @@
+import os
+import time
+
+import requests
+from openai import OpenAI
+
+
+class OllamaLocal:
+    def __init__(
+        self,
+        model_name,
+        base_url=None,
+        temperature=0.0,
+        max_output_tokens=4096,
+        n_retries=6,
+        retry_wait=5,
+    ):
+        self.model_name = model_name
+        self.base_url = (base_url or os.environ.get("GAMEBOT_OLLAMA_BASE_URL") or "http://127.0.0.1:11434").rstrip("/")
+        self.temperature = temperature
+        self.max_output_tokens = max_output_tokens
+        self.n_retries = n_retries
+        self.retry_wait = retry_wait
+
+    def get_response_text(self, prompt):
+        payload = {
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "options": {
+                "temperature": self.temperature,
+                "num_predict": self.max_output_tokens,
+            },
+        }
+        last_error = None
+        for i in range(self.n_retries):
+            try:
+                response = requests.post(f"{self.base_url}/api/chat", json=payload, timeout=600)
+                response.raise_for_status()
+                data = response.json()
+                return data.get("message", {}).get("content", "")
+            except Exception as e:
+                last_error = e
+                print(f"Request failed for Ollama local model: {e}")
+                time.sleep(self.retry_wait * (i + 1))
+        return f"None - failed to generate content after {self.n_retries} tries: {last_error}"
+
+
+class OpenAICompatibleLocal:
+    def __init__(
+        self,
+        model_name,
+        base_url=None,
+        api_key=None,
+        temperature=0.0,
+        max_output_tokens=4096,
+        n_retries=6,
+        retry_wait=5,
+    ):
+        self.model_name = model_name
+        self.client = OpenAI(
+            base_url=base_url or os.environ.get("GAMEBOT_OPENAI_BASE_URL") or "http://127.0.0.1:8000/v1",
+            api_key=api_key or os.environ.get("GAMEBOT_OPENAI_API_KEY") or "EMPTY",
+        )
+        self.temperature = temperature
+        self.max_output_tokens = max_output_tokens
+        self.n_retries = n_retries
+        self.retry_wait = retry_wait
+
+    def get_response_text(self, prompt):
+        last_error = None
+        for i in range(self.n_retries):
+            try:
+                response = self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=self.temperature,
+                    max_tokens=self.max_output_tokens,
+                )
+                return response.choices[0].message.content
+            except Exception as e:
+                last_error = e
+                print(f"Request failed for OpenAI-compatible local model: {e}")
+                time.sleep(self.retry_wait * (i + 1))
+        return f"None - failed to generate content after {self.n_retries} tries: {last_error}"

--- a/agent_list/__init__.py
+++ b/agent_list/__init__.py
@@ -1,19 +1,6 @@
 import random
 
-from .Groq import Groq4Game
-from .Kimi import Kimi
-from .OpenAI import OpenAI, AzOpenAI
-from .Vertex import Vertex
-from .Claude import Claude
-# from .Command_R import Command_R
-from .Jamba import Jamba
-from .LLaMA3_1 import LLaMA3_1
-from .Mistral import Mistral
-# from .Phi import Phi
-from .Gemini import Gemini
-from .Reka import Reka
 import keys
-from .DeepSeek_ByteDance import DeepSeekR1
 
 import os
 # proxy = 'http://127.0.0.1:7890'
@@ -38,11 +25,31 @@ class InitAgent:
     def init_agent(self, agent_str, max_output_tokens=4096, temperature=0.0,
                    top_k=1, seed=42, project_id="llmsasagents", default_parameters=True,
                    n_retries=6, retry_wait=10):
-        if agent_str == 'gemini-1.0-pro-latest' or agent_str == 'gemini-1.5-flash-001' or agent_str == 'gemini-exp-1206':
+        if agent_str.startswith("ollama:"):
+            from .Local import OllamaLocal
+            agent = OllamaLocal(
+                model_name=agent_str.split(":", 1)[1],
+                temperature=temperature,
+                max_output_tokens=max_output_tokens,
+                n_retries=n_retries,
+                retry_wait=retry_wait,
+            )
+        elif agent_str.startswith("openai-local:") or agent_str.startswith("vllm:") or agent_str.startswith("sglang:"):
+            from .Local import OpenAICompatibleLocal
+            agent = OpenAICompatibleLocal(
+                model_name=agent_str.split(":", 1)[1],
+                temperature=temperature,
+                max_output_tokens=max_output_tokens,
+                n_retries=n_retries,
+                retry_wait=retry_wait,
+            )
+        elif agent_str == 'gemini-1.0-pro-latest' or agent_str == 'gemini-1.5-flash-001' or agent_str == 'gemini-exp-1206':
+            from .Gemini import Gemini
             agent = Gemini(model_name=agent_str,
                            api_key=keys.gemini_api_key_list[random.choice(range(0, len(keys.gemini_api_key_list)))])
         # -- Gemini via Vertex -- #
         elif agent_str.startswith('gemini'):
+            from .Vertex import Vertex
             # agent = Gemini(model_name=agent_str, api_key=keys.gemini_api_key_list[self.init_gemini_time])
             # self.init_gemini_time += 1
             agent = Vertex(agent_str,
@@ -54,18 +61,22 @@ class InitAgent:
                            n_retries=n_retries,
                            retry_wait=retry_wait)
         elif 'deepseek' in agent_str:
+            from .DeepSeek_ByteDance import DeepSeekR1
             agent = DeepSeekR1(keys.bytedance_key, max_output_tokens=8192)
         # -- Kimi -- #
         elif agent_str.startswith('kimi'):
+            from .Kimi import Kimi
             agent = Kimi(api_key=keys.kimi_api_key)
 
         # -- Command-R -- #
         elif 'command' in agent_str:
+            from .Command_R import Command_R
             agent = Command_R(agent_str,
                               temperature=temperature,
                               max_output_tokens=max_output_tokens,
                               default_parameters=default_parameters)
         elif 'jamba' in agent_str:
+            from .Jamba import Jamba
             agent = Jamba(agent_str,
                           temperature=temperature,
                           max_output_tokens=max_output_tokens,
@@ -74,6 +85,7 @@ class InitAgent:
                           n_retries=n_retries,
                           retry_wait=retry_wait)
         elif 'meta' in agent_str:
+            from .LLaMA3_1 import LLaMA3_1
             agent = LLaMA3_1(agent_str,
                              temperature=temperature,
                              max_output_tokens=max_output_tokens,
@@ -82,6 +94,7 @@ class InitAgent:
                              n_retries=n_retries,
                              retry_wait=retry_wait)
         elif 'mistral' in agent_str:
+            from .Mistral import Mistral
             agent = Mistral(agent_str,
                             temperature=temperature,
                             max_output_tokens=max_output_tokens,
@@ -93,6 +106,7 @@ class InitAgent:
                             retry_wait=retry_wait)
 
         elif 'phi' in agent_str:
+            from .Phi import Phi
             agent = Phi(agent_str,
                         temperature=temperature,
                         max_output_tokens=max_output_tokens,
@@ -101,6 +115,7 @@ class InitAgent:
                         retry_wait=retry_wait)
 
         elif 'reka' in agent_str:
+            from .Reka import Reka
             agent = Reka(agent_str,
                          api_key=keys.reka_key,
                          temperature=temperature,
@@ -112,6 +127,7 @@ class InitAgent:
 
         # -- GPT models via AzureOpenAI -- #
         elif agent_str.startswith('gpt'):
+            from .OpenAI import AzOpenAI
             azure_endpoint = ["https://baairl-eastus2.openai.azure.com/", \
                               "https://llambda-us.openai.azure.com"]
             if agent_str == 'gpt-4o' or agent_str == 'gpt-4o-mini':
@@ -134,6 +150,7 @@ class InitAgent:
                 raise ValueError(f"Unsupported model {agent_str}")
         # -- OpenAI models -- #
         elif agent_str.startswith('o1') or agent_str.startswith('o3'):
+            from .OpenAI import OpenAI
             agent = OpenAI(model_name=agent_str,
                            api_key=keys.openai_key,
                            temperature=temperature,
@@ -142,6 +159,7 @@ class InitAgent:
                            default_parameters=default_parameters)
         # -- Claude models via Vertex -- #
         elif agent_str.startswith('claude'):
+            from .Claude import Claude
             agent = Claude(model_name=agent_str,
                            temperature=temperature,
                            top_k=top_k,
@@ -153,6 +171,7 @@ class InitAgent:
         elif agent_str == 'random':
             agent = RandomAgent()
         else:
+            from .Groq import Groq4Game
             agent = Groq4Game(model_name=agent_str,
                               api_key=keys.groq_api_key_list[random.choice(range(0, len(keys.groq_api_key_list)))])
             self.init_groq_time += 1

--- a/prompt_field_rationale.py
+++ b/prompt_field_rationale.py
@@ -1,0 +1,186 @@
+"""Field-rationale prompt variants for GAMEBoT prompts.
+
+The final action sections are intentionally preserved so existing parsers such as
+`Chosen Move`, `Chosen Action`, and `Proposal` keep working.
+"""
+
+FIELD_REGISTERS = {
+    "tictactoe": [
+        "board_state",
+        "legal_empty_squares",
+        "own_immediate_winning_moves",
+        "opponent_immediate_winning_moves",
+        "center_corner_edge_value",
+        "candidate_move_values",
+    ],
+    "connect4": [
+        "board_state",
+        "legal_drop_columns",
+        "own_immediate_winning_moves",
+        "opponent_immediate_winning_moves",
+        "center_column_control",
+        "multi_threat_creation",
+        "candidate_move_values",
+    ],
+    "othello": [
+        "board_state",
+        "legal_moves",
+        "corner_control",
+        "edge_control",
+        "piece_stability",
+        "frontier_discs",
+        "wedge_opportunities",
+        "mobility",
+        "candidate_move_values",
+    ],
+    "checkers": [
+        "board_state",
+        "legal_moves",
+        "mandatory_capture_options",
+        "king_promotion_moves",
+        "worthless_die_risk",
+        "two_for_one_shots",
+        "piece_safety_and_material",
+        "candidate_move_values",
+    ],
+    "pong": [
+        "ball_direction",
+        "ball_trajectory_to_paddle",
+        "own_paddle_position",
+        "opponent_paddle_position",
+        "wall_rebound_prediction",
+        "intercept_position_value",
+        "candidate_action_values",
+    ],
+    "surround": [
+        "current_position",
+        "adjacent_cell_values",
+        "valid_move_set",
+        "future_empty_space",
+        "self_trap_risk",
+        "opponent_trap_opportunity",
+        "candidate_action_values",
+    ],
+    "negotiate": [
+        "pool_and_private_values",
+        "latest_proposal_value",
+        "proposal_history_trend",
+        "opponent_value_beliefs",
+        "round_end_risk",
+        "proposal_validity",
+        "candidate_proposal_values",
+    ],
+    "texas": [
+        "private_cards",
+        "community_cards",
+        "available_betting_actions",
+        "hand_strength_or_equity",
+        "pot_commitment",
+        "opponent_betting_pressure",
+        "candidate_action_values",
+    ],
+}
+
+FINAL_SECTION_MARKERS = [
+    "**[Action]**",
+    "3. **Chosen Move**",
+    "4. **Chosen Move**",
+    "5. **Chosen Action**",
+    "3. **Chosen Action**",
+    "5. **Proposal**",
+]
+
+PROCESS_MARKER = "Follow the thinking process:"
+
+
+def normalize_prompt_type(prompt_type):
+    if prompt_type in {None, "", "cot", "naive", "no", "original"}:
+        return "original"
+    if prompt_type in {"field_aux", "field_only"}:
+        return prompt_type
+    raise ValueError(
+        f"Unsupported prompt_type={prompt_type!r}; use original, field_aux, or field_only."
+    )
+
+
+def _field_register_block(game_name):
+    fields = FIELD_REGISTERS[game_name]
+    return "\n".join(f"- {field}" for field in fields)
+
+
+def _field_section(game_name):
+    return f"""
+
+**Decision Fields**
+Use the Field Register only as a compact way to explain the reasoning behind your chosen move or action.
+Do not treat the fields as additional game rules or extra available actions.
+
+Field Register:
+{_field_register_block(game_name)}
+
+Field Selection Rule:
+Select 2 to 4 fields from the Field Register.
+Prefer the smallest sufficient set of fields for the decision.
+Use only fields that directly affect the chosen move or action; do not include fields that are only generally relevant.
+Use 4 fields only when multiple competing factors materially affect the decision.
+
+Before the final chosen move/action section, include:
+{{
+  "used_fields": [
+    "2 to 4 field names copied exactly from the Field Register"
+  ],
+  "field_analysis": [
+    {{
+      "field": "one exact field name from used_fields",
+      "value": "short phrase explaining why that field supports the selected move or action"
+    }}
+  ]
+}}
+
+Rules:
+- used_fields must contain 2 to 4 field names copied exactly from the Field Register.
+- field_analysis must contain exactly one object per used field, in the same order.
+- Keep each field_analysis.value short.
+"""
+
+
+def _find_final_marker(prompt):
+    positions = [
+        (prompt.find(marker), marker)
+        for marker in FINAL_SECTION_MARKERS
+        if prompt.find(marker) != -1
+    ]
+    if not positions:
+        return -1, None
+    return min(positions, key=lambda item: item[0])
+
+
+def _insert_before_final_section(prompt, section):
+    idx, _ = _find_final_marker(prompt)
+    if idx == -1:
+        return prompt.rstrip() + section
+    return prompt[:idx].rstrip() + section + "\n\n" + prompt[idx:]
+
+
+def _replace_process_with_field_section(prompt, section):
+    process_idx = prompt.find(PROCESS_MARKER)
+    final_idx, _ = _find_final_marker(prompt)
+    if process_idx == -1 or final_idx == -1 or final_idx <= process_idx:
+        return _insert_before_final_section(prompt, section)
+    prefix = prompt[: process_idx + len(PROCESS_MARKER)].rstrip()
+    final_section = prompt[final_idx:].lstrip()
+    return prefix + section + "\n\n" + final_section
+
+
+def build_gamebot_prompt(game_name, base_prompt, prompt_type="original", role=None):
+    prompt_type = normalize_prompt_type(prompt_type)
+    if prompt_type == "original":
+        return base_prompt
+    if game_name not in FIELD_REGISTERS:
+        raise ValueError(f"No Field Register configured for game_name={game_name!r}")
+    section = _field_section(game_name)
+    if role:
+        section = section.replace("**Decision Fields**", f"**Decision Fields ({role})**", 1)
+    if prompt_type == "field_aux":
+        return _insert_before_final_section(base_prompt, section)
+    return _replace_process_with_field_section(base_prompt, section)

--- a/run_games_and_check/checkers.py
+++ b/run_games_and_check/checkers.py
@@ -4,6 +4,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir) # add path
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import argparse
@@ -51,13 +52,17 @@ def main():
     # agent2_str = 'mixtral-8x7b-32768'
     agent1_str = args.agent1_str
     agent2_str = args.agent2_str
+    prompt1 = build_gamebot_prompt("checkers", system_prompt_checkers, args.prompt_type_agent1, role="player White")
+    prompt2 = build_gamebot_prompt("checkers", system_prompt_checkers, args.prompt_type_agent2, role="player Black")
+    agent1_label = agent1_str if agent1_str == "random" else agent1_str + "_" + args.prompt_type_agent1
+    agent2_label = agent2_str if agent2_str == "random" else agent2_str + "_" + args.prompt_type_agent2
     cycles = args.cycles
     agent1_scores = 0
     agent2_scores = 0
     init_agent = InitAgent(key_start=args.key_start)
     agent1 = init_agent.init_agent(agent1_str)
     agent2 = init_agent.init_agent(agent2_str)
-    run_category = 'running_log/checkers/{}_vs_{}_'.format(agent1_str, agent2_str) + date_string
+    run_category = 'running_log/checkers/{}_vs_{}_'.format(agent1_label, agent2_label) + date_string
 
     if not os.path.exists(run_category):
         # Create the directory
@@ -75,13 +80,14 @@ def main():
     logger1.setLevel(logging.INFO)
     logger2.setLevel(logging.INFO)
     logger_game.setLevel(logging.INFO)
-    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_str))
-    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_str))
+    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_label))
+    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_label))
     file_handler_game = logging.FileHandler('{}/game.log'.format(run_category))
     logger1.addHandler(file_handler1)
     logger2.addHandler(file_handler2)
     logger_game.addHandler(file_handler_game)
-    logger_game.info(system_prompt_checkers)
+    logger_game.info('Prompt1:\n {}'.format(prompt1))
+    logger_game.info('Prompt2:\n {}'.format(prompt2))
     count_for_request = 0
     start_time = time.time()
 
@@ -108,8 +114,8 @@ def main():
                 else:
                     state_prompt+='Current valid moves for player White: '+str(game.board.get_possible_moves_rowcol())+'\n'
                     state_prompt+='You are player White, please choose the best move considering the current board state.\n'
-                    actions = call_llm_api(state_prompt, system_prompt_checkers, logger1, agent1)
-                logger_game.info(f'{agent1_str} takes move ({actions[0]},{actions[1]})->({actions[2]},{actions[3]})')
+                    actions = call_llm_api(state_prompt, prompt1, logger1, agent1)
+                logger_game.info(f'{agent1_label} takes move ({actions[0]},{actions[1]})->({actions[2]},{actions[3]})')
                     
             else:
                 if agent2_str == 'random':
@@ -118,8 +124,8 @@ def main():
                 else:
                     state_prompt+='Current valid moves for player Black: '+str(game.board.get_possible_moves_rowcol())+'\n'
                     state_prompt+='You are player Black, please choose the best move considering the current board state.\n'
-                    actions = call_llm_api(state_prompt, system_prompt_checkers, logger2, agent2)
-                logger_game.info(f'{agent2_str} takes move ({actions[0]},{actions[1]})->({actions[2]},{actions[3]})')
+                    actions = call_llm_api(state_prompt, prompt2, logger2, agent2)
+                logger_game.info(f'{agent2_label} takes move ({actions[0]},{actions[1]})->({actions[2]},{actions[3]})')
 
             game.move_with_rowcol(actions[0], actions[1], actions[2], actions[3])
 
@@ -134,16 +140,16 @@ def main():
             logger_game.info(f"Duration: {hours} hours, {minutes} minutes, {seconds} seconds")
 
         if game.get_winner()==1:
-            log_result_str = f'{agent1_str} wins!!!!!!!!!'
+            log_result_str = f'{agent1_label} wins!!!!!!!!!'
             agent1_scores += 1
 
         elif game.get_winner()==2:
-            log_result_str = f'{agent2_str} wins!!!!!!!!!'
+            log_result_str = f'{agent2_label} wins!!!!!!!!!'
             agent2_scores += 1
         else:
             log_result_str = 'Draw!!!!!!!!!'
         logger_game.info(log_result_str)
-    logger_game.info('Final score: {} {}:{} {}; total {} requests'.format(agent1_str, agent1_scores, agent2_str, agent2_scores, count_for_request))
+    logger_game.info('Final score: {} {}:{} {}; total {} requests'.format(agent1_label, agent1_scores, agent2_label, agent2_scores, count_for_request))
 # Create the parser
 parser = argparse.ArgumentParser(description='Parser for test of agent')
 
@@ -152,6 +158,8 @@ parser.add_argument('agent1_str', help='Path to the input file')
 parser.add_argument('agent2_str', help='Path to the output file')
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='Times of game cycles', default=0)
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 
 # Parse the arguments
 args = parser.parse_args()

--- a/run_games_and_check/connect4.py
+++ b/run_games_and_check/connect4.py
@@ -6,6 +6,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)  # add path
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import random
@@ -22,8 +23,8 @@ parser.add_argument('agent1_str', help='Path to the input file')
 parser.add_argument('agent2_str', help='Path to the output file')
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='Times of game cycles', default=0)
-parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt, no|naive|cot', default='cot')
-parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt, no|naive|cot', default='cot')
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 
 # Parse the arguments
 args = parser.parse_args()
@@ -79,9 +80,10 @@ rgb_list = []
 count_for_request = 0
 start_time = time.time()
 
-prompt1 = system_prompt_connect4
-prompt2 = system_prompt_connect4
+prompt1 = build_gamebot_prompt(game_str, system_prompt_connect4, args.prompt_type_agent1, role="player X")
+prompt2 = build_gamebot_prompt(game_str, system_prompt_connect4, args.prompt_type_agent2, role="player O")
 logger_game.info('Prompt1:\n {}'.format(prompt1))
+logger_game.info('Prompt2:\n {}'.format(prompt2))
 
 
 # common setup end =========================

--- a/run_games_and_check/multi-agent-asyn-atari_pong.py
+++ b/run_games_and_check/multi-agent-asyn-atari_pong.py
@@ -9,6 +9,7 @@ parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)  # add path
 from utils.get_real_position import *
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import asyncio
@@ -19,12 +20,12 @@ from agent_list import InitAgent
 from utils.util import ram2label, find_action
 
 
-async def async_call_llm_api(frame_input, logger, agent, agent_str):
+async def async_call_llm_api(frame_input, system_prompt, logger, agent, agent_str):
     if agent_str == 'random':
         return random.choice([0, 1, 2])
     else:
         logger.info(frame_input)
-        final_input1 = system_prompt_pong + frame_input
+        final_input1 = system_prompt + frame_input
         response = agent.get_response_text(final_input1)
         if response.startswith("None - failed to generate content after"):
             logger.info('None - failed to generate content')
@@ -49,6 +50,10 @@ async def main():
     # agent2_str = 'mixtral-8x7b-32768'
     agent1_str = args.agent1_str
     agent2_str = args.agent2_str
+    prompt1 = build_gamebot_prompt("pong", system_prompt_pong, args.prompt_type_agent1, role="right paddle")
+    prompt2 = build_gamebot_prompt("pong", system_prompt_pong, args.prompt_type_agent2, role="left paddle")
+    agent1_label = agent1_str if agent1_str == "random" else agent1_str + "_" + args.prompt_type_agent1
+    agent2_label = agent2_str if agent2_str == "random" else agent2_str + "_" + args.prompt_type_agent2
     game_str = "pong"
     cycles = args.cycles
     agent1_scores = 0
@@ -57,7 +62,7 @@ async def main():
     init_agent = InitAgent(key_start=args.key_start)
     agent1 = init_agent.init_agent(agent1_str)
     agent2 = init_agent.init_agent(agent2_str)
-    run_category = 'running_log/{}/{}_vs_{}_'.format(game_str, agent1_str, agent2_str) + date_string
+    run_category = 'running_log/{}/{}_vs_{}_'.format(game_str, agent1_label, agent2_label) + date_string
 
     if not os.path.exists(run_category):
         # Create the directory
@@ -75,15 +80,19 @@ async def main():
     logger1.setLevel(logging.INFO)
     logger2.setLevel(logging.INFO)
     logger_game.setLevel(logging.INFO)
-    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_str))
-    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_str))
+    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_label))
+    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_label))
     file_handler_game = logging.FileHandler('{}/game.log'.format(run_category))
     logger1.addHandler(file_handler1)
     logger2.addHandler(file_handler2)
     logger_game.addHandler(file_handler_game)
     # logging.basicConfig(filename='{}/logfile.log'.format(run_category), level=logging.INFO)
 
-    env = pong_v3.parallel_env(num_players=2, render_mode="rgb_array",auto_rom_install_path='path/to/roms')
+    rom_root = os.environ.get(
+        "GAMEBOT_ATARI_ROM_ROOT",
+        "/home/user/miniconda3/envs/theorygame/lib/python3.13/site-packages/multi_agent_ale_py",
+    )
+    env = pong_v3.parallel_env(num_players=2, render_mode="rgb_array", auto_rom_install_path=rom_root)
     env.reset(seed=random.randint(0, 9999))
     rgb_list = []
     action2 = 0
@@ -129,8 +138,8 @@ async def main():
                             step - 2,str(refined_info_queue[1]),step - 1,str(refined_info_queue[2]),step,str(refined_info_queue[3]))
                         frame_input2 = 'Input:\n\n Frame {}\n {} \n Frame {}\n {}\n Frame {}\n {} \nOutput:'.format(
                             step - 2,str(info_flipped_queue[1]),step - 1,str(info_flipped_queue[2]),step,str(info_flipped_queue[3]))
-                        task1 = async_call_llm_api(frame_input1, logger1, agent1, agent1_str)
-                        task2 = async_call_llm_api(frame_input2, logger2, agent2, agent2_str)
+                        task1 = async_call_llm_api(frame_input1, prompt1, logger1, agent1, agent1_str)
+                        task2 = async_call_llm_api(frame_input2, prompt2, logger2, agent2, agent2_str)
                         action_gather = await asyncio.gather(task1, task2)
                         action1 = action_gather[0]
                         action2 = action_gather[1]
@@ -138,7 +147,7 @@ async def main():
                             logger_game.info('Rate limit or network problem, break')
                             break
                         logger_game.info(
-                            '{} takes action {}; {} takes action {}'.format(agent1_str, action1, agent2_str, action2))
+                            '{} takes action {}; {} takes action {}'.format(agent1_label, action1, agent2_label, action2))
 
                         curr_time = time.time()
                         duration_seconds = curr_time - start_time
@@ -165,13 +174,13 @@ async def main():
 
                         if labels['player_score'] == 1:
                             logger_game.info(
-                                f"{agent1_str} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
+                                f"{agent1_label} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
                             agent1_scores += 1
                             env.reset(seed=random.randint(0, 9999))
                             break
                         if labels['enemy_score'] == 1:
                             logger_game.info(
-                                f"{agent2_str} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
+                                f"{agent2_label} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
                             agent2_scores += 1
                             env.reset(seed=random.randint(0, 9999))
                             break
@@ -190,11 +199,13 @@ async def main():
         # if step > 100:
         #     break
         # if labels
-    save_video(rgb_list[60:], run_category, fps=60, step_starting_index=0, episode_index=0,
-               name_prefix='{}_vs_{}'.format(agent1_str, agent2_str))
+    video_frames = rgb_list[60:]
+    if video_frames:
+        save_video(video_frames, run_category, fps=60, step_starting_index=0, episode_index=0,
+                   name_prefix='{}_vs_{}'.format(agent1_label, agent2_label))
     env.close()
     logger_game.info(
-        'Final result: {} scores {}, and {} scores {}, draw {} times'.format(agent1_str, agent1_scores, agent2_str,
+        'Final result: {} scores {}, and {} scores {}, draw {} times'.format(agent1_label, agent1_scores, agent2_label,
                                                                              agent2_scores, draw_scores))
 
 
@@ -209,6 +220,8 @@ parser.add_argument('agent2_str', help='agent2')
 
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='Times of game cycles', default=0)
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 # Parse the arguments
 args = parser.parse_args()
 asyncio.run(main())

--- a/run_games_and_check/negotiate.py
+++ b/run_games_and_check/negotiate.py
@@ -8,6 +8,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)  # add path
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import argparse
@@ -27,7 +28,8 @@ def random_agent_negotiate(pool_values):
 def main():
     # ---------------To be modified: define game and prompt----------------
     game_str = "negotiate"
-    system_prompt = system_prompt_negotiate
+    system_prompt1 = build_gamebot_prompt(game_str, system_prompt_negotiate, args.prompt_type_agent1, role="Player1")
+    system_prompt2 = build_gamebot_prompt(game_str, system_prompt_negotiate, args.prompt_type_agent2, role="Player2")
     # ---------------------------------------------
 
     current_time = datetime.now()
@@ -36,6 +38,8 @@ def main():
     print(date_string)
     agent1_str = args.agent1_str
     agent2_str = args.agent2_str
+    agent1_label = agent1_str if agent1_str == "random" else agent1_str + "_" + args.prompt_type_agent1
+    agent2_label = agent2_str if agent2_str == "random" else agent2_str + "_" + args.prompt_type_agent2
     cycles = args.cycles
     agent1_scores = 0
     agent2_scores = 0
@@ -52,7 +56,7 @@ def main():
         os.mkdir(run_category_game)
         print("Directory created:", run_category_game)
 
-    run_category = run_category_game + '/{}_vs_{}_'.format(agent1_str, agent2_str) + date_string + ''.join(
+    run_category = run_category_game + '/{}_vs_{}_'.format(agent1_label, agent2_label) + date_string + ''.join(
         random.choices(
             'abcdefghijklmnopqrstuvwxyz', k=2))
 
@@ -71,14 +75,15 @@ def main():
     logger1.setLevel(logging.INFO)
     logger2.setLevel(logging.INFO)
     logger_game.setLevel(logging.INFO)
-    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_str))
-    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_str))
+    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_label))
+    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_label))
     file_handler_game = logging.FileHandler('{}/game.log'.format(run_category))
     logger1.addHandler(file_handler1)
     logger2.addHandler(file_handler2)
     logger_game.addHandler(file_handler_game)
 
-    logger_game.info(system_prompt)
+    logger_game.info('Prompt1:\n {}'.format(system_prompt1))
+    logger_game.info('Prompt2:\n {}'.format(system_prompt2))
     count_for_request = 0
     start_time = time.time()
 
@@ -108,7 +113,7 @@ def main():
                     actions = random_agent_negotiate(pool_values)
                     intermediate_results=[-1,-1]
                 else:
-                    intermediate_results, actions = call_llm_api_check_intermediate(state_prompt_p1, system_prompt, logger1, agent1, game_str)
+                    intermediate_results, actions = call_llm_api_check_intermediate(state_prompt_p1, system_prompt1, logger1, agent1, game_str)
                 check_results = game_env.check_intermediate_results(intermediate_results, actions)
                 agent1_intermediate_correct += check_results[0]
                 agent1_intermediate_total += check_results[1]
@@ -119,7 +124,7 @@ def main():
                     actions = random_agent_negotiate(pool_values)
                     intermediate_results=[-1,-1]
                 else:
-                    intermediate_results, actions = call_llm_api_check_intermediate(state_prompt_p2, system_prompt, logger2, agent2, game_str)
+                    intermediate_results, actions = call_llm_api_check_intermediate(state_prompt_p2, system_prompt2, logger2, agent2, game_str)
                 check_results = game_env.check_intermediate_results(intermediate_results, actions)
                 agent2_intermediate_correct += check_results[0]
                 agent2_intermediate_total += check_results[1]
@@ -144,10 +149,12 @@ def main():
 
     # ---------------To be modified: log final results----------------
     logger_game.info(
-        'Final score: {} {}:{} {}; total {} requests for two agents'.format(agent1_str, agent1_scores, agent2_str,
+        'Final score: {} {}:{} {}; total {} requests for two agents'.format(agent1_label, agent1_scores, agent2_label,
                                                                             agent2_scores, count_for_request))
-    logger_game.info('Agent1 intermediate correct rate: {}/{}, {}'.format(agent1_intermediate_correct, agent1_intermediate_total, agent1_intermediate_correct/agent1_intermediate_total))
-    logger_game.info('Agent2 intermediate correct rate: {}/{}, {}'.format(agent2_intermediate_correct, agent2_intermediate_total, agent2_intermediate_correct/agent2_intermediate_total))
+    agent1_rate = agent1_intermediate_correct / agent1_intermediate_total if agent1_intermediate_total else 0.0
+    agent2_rate = agent2_intermediate_correct / agent2_intermediate_total if agent2_intermediate_total else 0.0
+    logger_game.info('Agent1 intermediate correct rate: {}/{}, {}'.format(agent1_intermediate_correct, agent1_intermediate_total, agent1_rate))
+    logger_game.info('Agent2 intermediate correct rate: {}/{}, {}'.format(agent2_intermediate_correct, agent2_intermediate_total, agent2_rate))
     # ---------------------------------------------
 
 
@@ -159,6 +166,8 @@ parser.add_argument('agent1_str', type=str, help='Agent 1 string')
 parser.add_argument('agent2_str', type=str, help='Agent 2 string')
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='', default=0)
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 # Parse the arguments
 args = parser.parse_args()
 main()

--- a/run_games_and_check/othello.py
+++ b/run_games_and_check/othello.py
@@ -8,6 +8,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir) # add path
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import pdb
@@ -17,12 +18,12 @@ from game_env.othello import Othello
 import re
 
 
-def async_call_llm_api(frame_input, logger, agent, agent_str, random_move):
+def async_call_llm_api(frame_input, system_prompt, logger, agent, agent_str, random_move):
     if agent_str == 'random':
         return random_move
     else:
         logger.info(frame_input)
-        final_input1 = system_prompt_othello + frame_input
+        final_input1 = system_prompt + frame_input
         response = ''
         while len(response) == 0:
             response = agent.get_response_text(final_input1)
@@ -59,13 +60,17 @@ def main():
     # agent2_str = 'mixtral-8x7b-32768'
     agent1_str = args.agent1_str
     agent2_str = args.agent2_str
+    prompt1 = build_gamebot_prompt("othello", system_prompt_othello, args.prompt_type_agent1, role="agent1")
+    prompt2 = build_gamebot_prompt("othello", system_prompt_othello, args.prompt_type_agent2, role="agent2")
+    agent1_label = agent1_str if agent1_str == "random" else agent1_str + "_" + args.prompt_type_agent1
+    agent2_label = agent2_str if agent2_str == "random" else agent2_str + "_" + args.prompt_type_agent2
     cycles = args.cycles
     agent1_scores = 0
     agent2_scores = 0
     init_agent = InitAgent(key_start=args.key_start)
     agent1 = init_agent.init_agent(agent1_str)
     agent2 = init_agent.init_agent(agent2_str)
-    run_category = 'running_log/othello/{}_vs_{}_'.format(agent1_str, agent2_str) + date_string
+    run_category = 'running_log/othello/{}_vs_{}_'.format(agent1_label, agent2_label) + date_string
 
     if not os.path.exists(run_category):
         # Create the directory
@@ -82,13 +87,14 @@ def main():
     logger1.setLevel(logging.INFO)
     logger2.setLevel(logging.INFO)
     logger_game.setLevel(logging.INFO)
-    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_str))
-    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_str))
+    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_label))
+    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_label))
     file_handler_game = logging.FileHandler('{}/game.log'.format(run_category))
     logger1.addHandler(file_handler1)
     logger2.addHandler(file_handler2)
     logger_game.addHandler(file_handler_game)
-    logger_game.info(system_prompt_othello)
+    logger_game.info('Prompt1:\n {}'.format(prompt1))
+    logger_game.info('Prompt2:\n {}'.format(prompt2))
     # logging.basicConfig(filename='{}/logfile.log'.format(run_category), level=logging.INFO)
 
     # env.reset(seed=random.randint(0, 9999))
@@ -128,12 +134,12 @@ def main():
             else:
                 agent1_no_valid_moves = False
                 frame_input = game.move_with_hint()
-                col, row = async_call_llm_api(frame_input, logger1, agent1, agent1_str, game.force_move())
+                col, row = async_call_llm_api(frame_input, prompt1, logger1, agent1, agent1_str, game.force_move())
 
                 if not game.make_move(col, row):
                     force_penalty[0] += 1
                     col, row = game.force_move()
-                    print(f'wrong move of {agent1_str}!!!')
+                    print(f'wrong move of {agent1_label}!!!')
                     if not game.make_move(col, row):
                         pdb.set_trace()
                 action1 = (col, row)
@@ -151,9 +157,9 @@ def main():
             else:
                 agent2_no_valid_moves = False
                 frame_input = game.move_with_hint()
-                col, row = async_call_llm_api(frame_input, logger2, agent2, agent2_str, game.force_move())
+                col, row = async_call_llm_api(frame_input, prompt2, logger2, agent2, agent2_str, game.force_move())
                 if not game.make_move(col, row):
-                    print(f'wrong move of {agent2_str}!!!')
+                    print(f'wrong move of {agent2_label}!!!')
                     force_penalty[1] += 1
                     col, row = game.force_move()
                     if not game.make_move(col, row):
@@ -161,7 +167,7 @@ def main():
                 action2 = (col, row)
 
             logger_game.info(
-                '{} takes action {}; {} takes action {}'.format(agent1_str, action1, agent2_str, action2))
+                '{} takes action {}; {} takes action {}'.format(agent1_label, action1, agent2_label, action2))
 
             curr_time = time.time()
             duration_seconds = curr_time - start_time
@@ -176,13 +182,13 @@ def main():
         agent1_score, agent2_score = game.get_score()
         logger_game.info(
             'Final result: {} scores {} hint_penalty {} force_penalty {}, and {} scores {} hint_penalty {} force_penalty {}'.format(
-                agent1_str, agent1_score, hint_penalty[0], force_penalty[0], agent2_str, agent2_score, hint_penalty[1],
+                agent1_label, agent1_score, hint_penalty[0], force_penalty[0], agent2_label, agent2_score, hint_penalty[1],
                 force_penalty[1]))
         if agent1_score>agent2_score:
             agent1_scores += 1
         elif agent1_score<agent2_score:
             agent2_scores += 1
-    logger_game.info('Final score: {} {}:{} {}'.format(agent1_str, agent1_scores, agent2_scores, agent2_str))
+    logger_game.info('Final score: {} {}:{} {}'.format(agent1_label, agent1_scores, agent2_scores, agent2_label))
 # Create the parser
 parser = argparse.ArgumentParser(description='Parser for test of agent')
 
@@ -191,6 +197,8 @@ parser.add_argument('agent1_str', help='Path to the input file')
 parser.add_argument('agent2_str', help='Path to the output file')
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='Times of game cycles', default=0)
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 
 # Parse the arguments
 args = parser.parse_args()

--- a/run_games_and_check/surround.py
+++ b/run_games_and_check/surround.py
@@ -7,6 +7,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir) # add path
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import asyncio
@@ -48,6 +49,10 @@ async def main():
     # agent2_str = 'mixtral-8x7b-32768'
     agent1_str = args.agent1_str
     agent2_str = args.agent2_str
+    prompt1 = build_gamebot_prompt("surround", system_prompt_surround_agent1, args.prompt_type_agent1, role="agent1")
+    prompt2 = build_gamebot_prompt("surround", system_prompt_surround_agent2, args.prompt_type_agent2, role="agent2")
+    agent1_label = agent1_str if agent1_str == "random" else agent1_str + "_" + args.prompt_type_agent1
+    agent2_label = agent2_str if agent2_str == "random" else agent2_str + "_" + args.prompt_type_agent2
     game_str = "surround"
     cycles = args.cycles
     agent1_scores = 0
@@ -57,7 +62,7 @@ async def main():
     agent1 = init_agent.init_agent(agent1_str)
     agent2 = init_agent.init_agent(agent2_str)
     # action1_list = [1,1,2,2,3,3,4,4,1,1,2,2,3,3,4,4]
-    run_category = 'running_log/{}/{}_vs_{}_'.format(game_str, agent1_str, agent2_str) + date_string
+    run_category = 'running_log/{}/{}_vs_{}_'.format(game_str, agent1_label, agent2_label) + date_string
 
     if not os.path.exists(run_category):
         # Create the directory
@@ -74,13 +79,17 @@ async def main():
     logger1.setLevel(logging.INFO)
     logger2.setLevel(logging.INFO)
     logger_game.setLevel(logging.INFO)
-    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_str))
-    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_str))
+    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_label))
+    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_label))
     file_handler_game = logging.FileHandler('{}/game.log'.format(run_category))
     logger1.addHandler(file_handler1)
     logger2.addHandler(file_handler2)
     logger_game.addHandler(file_handler_game)
-    env = surround_v2.parallel_env(render_mode="rgb_array", auto_rom_install_path='path/to/roms')
+    rom_root = os.environ.get(
+        "GAMEBOT_ATARI_ROM_ROOT",
+        "/home/user/miniconda3/envs/theorygame/lib/python3.13/site-packages/multi_agent_ale_py",
+    )
+    env = surround_v2.parallel_env(render_mode="rgb_array", auto_rom_install_path=rom_root)
     observations, infos = env.reset(seed=random.randint(0, 9999))
 
     rgb_list = []
@@ -89,8 +98,8 @@ async def main():
     start_time = time.time()
     rows = 20
     cols = 40
-    logger1.info('Prompt:\n {}'.format(system_prompt_surround_agent1))
-    logger2.info('Prompt:\n {}'.format(system_prompt_surround_agent2))
+    logger1.info('Prompt:\n {}'.format(prompt1))
+    logger2.info('Prompt:\n {}'.format(prompt2))
 
     for cycle in range(cycles):
         action2 = 0
@@ -175,8 +184,8 @@ async def main():
                         f" agent1 and agent2 collide, draw!!!!!!!!!!!!!! Cost total {count_for_request} requests")
                     render_longer = 80
 
-                task1 = async_call_llm_api(frame_input1, system_prompt_surround_agent1, logger1, agent1, agent1_str)
-                task2 = async_call_llm_api(frame_input2, system_prompt_surround_agent2, logger2, agent2, agent2_str)
+                task1 = async_call_llm_api(frame_input1, prompt1, logger1, agent1, agent1_str)
+                task2 = async_call_llm_api(frame_input2, prompt2, logger2, agent2, agent2_str)
                 action_gather = await asyncio.gather(task1, task2)
                 action1 = action_gather[0]
                 action2 = action_gather[1]
@@ -184,7 +193,7 @@ async def main():
                     logger_game.info('Rate limit or network problem, break')
                     break
                 logger_game.info(tabulate(game_state))
-                logger_game.info('{} takes action {}; {} takes action {}'.format(agent1_str, action1, agent2_str, action2))
+                logger_game.info('{} takes action {}; {} takes action {}'.format(agent1_label, action1, agent2_label, action2))
 
                 curr_time = time.time()
                 duration_seconds = curr_time - start_time
@@ -219,20 +228,21 @@ async def main():
             if rewards['first_0'] == 1 and render_longer == 0:
                 agent1_scores += 1
                 logger_game.info(
-                    f"{agent1_str} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
+                    f"{agent1_label} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
                 render_longer = 80
             if rewards['second_0'] == 1 and render_longer == 0:
                 agent2_scores += 1
                 logger_game.info(
-                    f"{agent2_str} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
+                    f"{agent2_label} wins!!!!!!!!!!!!!!!!!!!!!!!!!!! Cost total {count_for_request} requests")
                 render_longer = 80
             rgb_list.append(env.render())
 
-    save_video(rgb_list, run_category, fps=60, step_starting_index=0, episode_index=0,
-               name_prefix='{}_vs_{}'.format(agent1_str, agent2_str))
+    if rgb_list:
+        save_video(rgb_list, run_category, fps=60, step_starting_index=0, episode_index=0,
+                   name_prefix='{}_vs_{}'.format(agent1_label, agent2_label))
     env.close()
     logger_game.info(
-        'Final result: {} scores {}, and {} scores {}'.format(agent1_str, agent1_scores, agent2_str, agent2_scores))
+        'Final result: {} scores {}, and {} scores {}'.format(agent1_label, agent1_scores, agent2_label, agent2_scores))
 
 
 # Create the parser
@@ -245,6 +255,8 @@ parser.add_argument('agent2_str', help='agent2')
 
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='Times of game cycles', default=0)
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 # Parse the arguments
 args = parser.parse_args()
 asyncio.run(main())

--- a/run_games_and_check/texas_no_limit_v6.py
+++ b/run_games_and_check/texas_no_limit_v6.py
@@ -8,6 +8,7 @@ parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir) # add path
 
 from prompt_check_intermediate import *
+from prompt_field_rationale import build_gamebot_prompt
 import logging
 from datetime import datetime
 import argparse
@@ -118,7 +119,8 @@ def main():
 
     #---------------To be modified: define game and prompt----------------
     game_str = "texas_holdem"
-    system_prompt = system_prompt_texas_holdem
+    system_prompt1 = build_gamebot_prompt("texas", system_prompt_texas_holdem, args.prompt_type_agent1, role="player_0")
+    system_prompt2 = build_gamebot_prompt("texas", system_prompt_texas_holdem, args.prompt_type_agent2, role="player_1")
     #---------------------------------------------
 
     current_time = datetime.now()
@@ -127,6 +129,8 @@ def main():
     print(date_string)
     agent1_str = args.agent1_str
     agent2_str = args.agent2_str
+    agent1_label = agent1_str if agent1_str == "random" else agent1_str + "_" + args.prompt_type_agent1
+    agent2_label = agent2_str if agent2_str == "random" else agent2_str + "_" + args.prompt_type_agent2
     cycles = args.cycles
     agent1_scores = 0
     agent2_scores = 0
@@ -144,7 +148,7 @@ def main():
         os.makedirs(run_category_game, exist_ok=True)
         print("Directory created:", run_category_game)
 
-    run_category = run_category_game+'/{}_vs_{}_'.format(agent1_str, agent2_str) + date_string
+    run_category = run_category_game+'/{}_vs_{}_'.format(agent1_label, agent2_label) + date_string
 
     if not os.path.exists(run_category):
         # Create the directory
@@ -161,14 +165,15 @@ def main():
     logger1.setLevel(logging.INFO)
     logger2.setLevel(logging.INFO)
     logger_game.setLevel(logging.INFO)
-    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_str))
-    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_str))
+    file_handler1 = logging.FileHandler('{}/{}.log'.format(run_category, agent1_label))
+    file_handler2 = logging.FileHandler('{}/{}.log'.format(run_category, agent2_label))
     file_handler_game = logging.FileHandler('{}/game.log'.format(run_category))
     logger1.addHandler(file_handler1)
     logger2.addHandler(file_handler2)
     logger_game.addHandler(file_handler_game)
 
-    logger_game.info(system_prompt)
+    logger_game.info('Prompt1:\n {}'.format(system_prompt1))
+    logger_game.info('Prompt2:\n {}'.format(system_prompt2))
     count_for_request = 0
     start_time = time.time()
 
@@ -197,23 +202,23 @@ def main():
                 # ---------------To be modified: get game state from env and call llm to get actions----------------
                 if agent == 'player_0':
                     game_state = texas_class1.get_state_message(mask, observation)
-                    logger_game.info(f'\n{agent1_str}\'s turn------------')
+                    logger_game.info(f'\n{agent1_label}\'s turn------------')
                     logger_game.info(game_state)
                 else:
                     game_state = texas_class2.get_state_message(mask, observation)
-                    logger_game.info(f'\n{agent2_str}\'s turn------------')
+                    logger_game.info(f'\n{agent2_label}\'s turn------------')
                     logger_game.info(game_state)
 
                 state_prompt = 'Current Game State: \n\n' + game_state + '\n'
                 if agent=='player_0':
                     if agent1_str == 'random':
                         intermediate_results, action = random_texas(mask)
-                        logger_game.info(f'{agent1_str} {texas_class1.act2pos[action]}')
-                        print(f'{agent1_str} {texas_class1.act2pos[action]}')
+                        logger_game.info(f'{agent1_label} {texas_class1.act2pos[action]}')
+                        print(f'{agent1_label} {texas_class1.act2pos[action]}')
                     else:
-                        intermediate_results, action = call_llm_api_check_intermediate(state_prompt, system_prompt, logger1, agent1, "texas", find_action_function=texas_class1.find_action_texas)
-                        logger_game.info(f'{agent1_str} {texas_class1.act2pos[action]}')
-                        print(f'{agent1_str} {texas_class1.act2pos[action]}')
+                        intermediate_results, action = call_llm_api_check_intermediate(state_prompt, system_prompt1, logger1, agent1, "texas", find_action_function=texas_class1.find_action_texas)
+                        logger_game.info(f'{agent1_label} {texas_class1.act2pos[action]}')
+                        print(f'{agent1_label} {texas_class1.act2pos[action]}')
                     logger_game.info(f'Intermediate results: {intermediate_results}')
                     # check_results = check_intermediate_texas(intermediate_results, texas_class1.private, texas_class1.public)
                     # agent1_intermediate_correct += check_results[0]
@@ -221,12 +226,12 @@ def main():
                 else:
                     if agent2_str == 'random':
                         intermediate_results, action = random_texas(mask)
-                        logger_game.info(f'{agent2_str} {texas_class2.act2pos[action]}')
-                        print(f'{agent2_str} {texas_class2.act2pos[action]}')
+                        logger_game.info(f'{agent2_label} {texas_class2.act2pos[action]}')
+                        print(f'{agent2_label} {texas_class2.act2pos[action]}')
                     else:
-                        intermediate_results, action = call_llm_api_check_intermediate(state_prompt, system_prompt, logger2, agent2, "texas", find_action_function=texas_class2.find_action_texas)
-                        logger_game.info(f'{agent2_str} {texas_class2.act2pos[action]}')
-                        print(f'{agent2_str} {texas_class2.act2pos[action]}')
+                        intermediate_results, action = call_llm_api_check_intermediate(state_prompt, system_prompt2, logger2, agent2, "texas", find_action_function=texas_class2.find_action_texas)
+                        logger_game.info(f'{agent2_label} {texas_class2.act2pos[action]}')
+                        print(f'{agent2_label} {texas_class2.act2pos[action]}')
                     logger_game.info(f'Intermediate results: {intermediate_results}')
                     # check_results = check_intermediate_texas(intermediate_results, texas_class2.private, texas_class2.public)
                     # agent2_intermediate_correct += check_results[0]
@@ -258,11 +263,11 @@ def main():
             # ---------------------------------------------
         agent1_scores+=agent1_reward
         agent2_scores+=agent2_reward
-        logger_game.info('Cycle {} results: {} {}:{} {};'.format(cycle, agent1_str, agent1_reward, agent2_str, agent2_reward))
+        logger_game.info('Cycle {} results: {} {}:{} {};'.format(cycle, agent1_label, agent1_reward, agent2_label, agent2_reward))
         env.close()
 
     # ---------------To be modified: log final results----------------
-    logger_game.info('Final score: {} {}:{} {}; total {} requests'.format(agent1_str, agent1_scores, agent2_str, agent2_scores, count_for_request))
+    logger_game.info('Final score: {} {}:{} {}; total {} requests'.format(agent1_label, agent1_scores, agent2_label, agent2_scores, count_for_request))
     # logger_game.info('Agent1 intermediate correct rate: {}/{}, {}'.format(agent1_intermediate_correct, agent1_intermediate_total, agent1_intermediate_correct/agent1_intermediate_total))
     # logger_game.info('Agent2 intermediate correct rate: {}/{}, {}'.format(agent2_intermediate_correct, agent2_intermediate_total, agent2_intermediate_correct/agent2_intermediate_total))
     # ---------------------------------------------
@@ -275,6 +280,8 @@ parser.add_argument('agent1_str', type=str, help='Agent 1 string')
 parser.add_argument('agent2_str', type=str, help='Agent 2 string')
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--key_start', type=int, help='', default=0)
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 # Parse the arguments
 args = parser.parse_args()
 main()

--- a/run_games_and_check/tictactoe.py
+++ b/run_games_and_check/tictactoe.py
@@ -5,6 +5,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)  # add path
 from prompt_check_intermediate import system_prompt_tictactoe
+from prompt_field_rationale import build_gamebot_prompt
 from agent_list import InitAgent
 from datetime import datetime
 import argparse
@@ -19,8 +20,8 @@ parser.add_argument('agent2_str')
 parser.add_argument('--cycles', type=int, help='Times of game cycles', default=1)
 parser.add_argument('--test_type', help='Type of test', default='normal')
 parser.add_argument('--key_start', type=int, default=0)
-parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt, no|naive|cot', default='cot')
-parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt, no|naive|cot', default='cot')
+parser.add_argument('--prompt_type_agent1', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
+parser.add_argument('--prompt_type_agent2', type=str, help='Type of prompt: original|field_aux|field_only', default='original')
 
 # Parse the arguments
 args = parser.parse_args()
@@ -29,8 +30,8 @@ args = parser.parse_args()
 # else:
 #     system_prompt = system_prompt_tictactoe_llmarena
 
-prompt1 = system_prompt_tictactoe
-prompt2 = system_prompt_tictactoe
+prompt1 = build_gamebot_prompt("tictactoe", system_prompt_tictactoe, args.prompt_type_agent1, role="player X")
+prompt2 = build_gamebot_prompt("tictactoe", system_prompt_tictactoe, args.prompt_type_agent2, role="player O")
 current_time = datetime.now()
 date_string = current_time.strftime("%m-%d-%H-%M")
 
@@ -79,6 +80,7 @@ logger1.addHandler(file_handler1)
 logger2.addHandler(file_handler2)
 logger_game.addHandler(file_handler_game)
 logger_game.info('Prompt1:\n {}'.format(prompt1))
+logger_game.info('Prompt2:\n {}'.format(prompt2))
 
 
 def find_action(response):


### PR DESCRIPTION
Adds local Ollama/OpenAI-compatible model adapters and field-rationale prompt variants across GAMEBoT game runners.

Changes:
- Add Ollama and OpenAI-compatible local agent adapters.
- Add field rationale prompt construction.
- Add prompt type arguments to supported game runners.
- Keep experimental logs/results out of the commit.

Validation:
- Python compile checks passed for touched files.
- CLI help and random-agent smoke tests were checked locally before commit.